### PR TITLE
chore(xml): pass header to createEnvelope

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -250,13 +250,6 @@ class AmazonMwsClient {
     invoke(req, meta) {
         return req.query().then((q) => this.call(req, q, _.defaults(meta, this.meta)));
     }
-
-    /**
-     * Utility function to return the MerchantID for feed generation
-     */
-    getMerchantId() {
-      return this.merchantId;
-    }
 }
 
 module.exports = AmazonMwsClient;

--- a/lib/feeds/orders.js
+++ b/lib/feeds/orders.js
@@ -6,13 +6,11 @@ const errorNotImplemented = require('./index').errorNotImplemented;
 
 const arr = (collection) => _.compact(_.isArray(collection) ? collection : [collection]);
 
-const _POST_ORDER_ACKNOWLEDGEMENT_DATA_ = createEnvelope(function (client, data) {
-    const messages = Array.isArray(data) ? data : [data];
-
+const _POST_ORDER_ACKNOWLEDGEMENT_DATA_ = createEnvelope(function (header, data) {
     return {
-        MerchantIdentifier: client.getMerchantId(),
+        MerchantIdentifier: header.MerchantIdentifier,
         MessageType: 'OrderAcknowledgement',
-        Message: messages.map((m) => ({
+        Message: arr(data).map((m) => ({
             MessageID: m.MessageID,
             OrderAcknowledgement: {
                 AmazonOrderID: m.AmazonOrderID,
@@ -31,13 +29,11 @@ const _POST_ORDER_ACKNOWLEDGEMENT_DATA_ = createEnvelope(function (client, data)
 
 const _POST_PAYMENT_ADJUSTMENT_DATA_ = errorNotImplemented('_POST_PAYMENT_ADJUSTMENT_DATA_');
 
-const _POST_ORDER_FULFILLMENT_DATA_ = createEnvelope(function (client, data) {
-    const messages = Array.isArray(data) ? data : [data];
-
+const _POST_ORDER_FULFILLMENT_DATA_ = createEnvelope(function (header, data) {
     return {
-        MerchantIdentifier: client.getMerchantId(),
+        MerchantIdentifier: header.MerchantIdentifier,
         MessageType: 'OrderFulfillment',
-        Message: messages.map((m) => ({
+        Message: arr(data).map((m) => ({
             MessageID: m.MessageID,
             OrderFulfillment: {
                 AmazonOrderID: m.AmazonOrderID,

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -133,7 +133,7 @@ function makeXML(data) {
 
 const createXML = _.flowRight(makeXML, removeDuplicates, stripEmpty, stripUndefined);
 
-const createEnvelope = (fn) => (client, data) => createXML(AmazonEnvelope(fn(client, data)));
+const createEnvelope = (fn) => (header, data) => createXML(AmazonEnvelope(fn(header, data)));
 
 module.exports = {
     AmazonEnvelope,

--- a/test/xml.js
+++ b/test/xml.js
@@ -3,19 +3,14 @@
 const expect = require('chai').expect;
 
 const Feeds = require('../feeds');
-const MWSClient = require('../index');
 
 describe('xml', () => {
     describe('Feeds', () => {
         describe('_POST_ORDER_ACKNOWLEDGEMENT_DATA_', () => {
             it('should handle 0 items with basic data', () => {
-                const client = new MWSClient({
-                    accessKeyId: 'access',
-                    secretAccessKey: 'secret',
-                    merchantId: '67890'
-                });
-
-                const FeedContent = Feeds._POST_ORDER_ACKNOWLEDGEMENT_DATA_(client, {
+                const FeedContent = Feeds._POST_ORDER_ACKNOWLEDGEMENT_DATA_({
+                  MerchantIdentifier: '67890'
+                }, {
                     MessageID: 1,
                     AmazonOrderID: '123-4567890-1234567',
                     MerchantOrderID: '12345',
@@ -27,13 +22,9 @@ describe('xml', () => {
             });
 
             it('should handle 1 item with basic data', () => {
-                const client = new MWSClient({
-                    accessKeyId: 'access',
-                    secretAccessKey: 'secret',
-                    merchantId: '67890'
-                });
-
-                const FeedContent = Feeds._POST_ORDER_ACKNOWLEDGEMENT_DATA_(client, {
+                const FeedContent = Feeds._POST_ORDER_ACKNOWLEDGEMENT_DATA_({
+                  MerchantIdentifier: '67890'
+                }, {
                     MessageID: 1,
                     AmazonOrderID: '123-4567890-1234567',
                     MerchantOrderID: '12345',
@@ -50,13 +41,9 @@ describe('xml', () => {
             });
 
             it('should handle multiple order acknowledgement', () => {
-                const client = new MWSClient({
-                    accessKeyId: 'access',
-                    secretAccessKey: 'secret',
-                    merchantId: '67890'
-                });
-
-                const FeedContent = Feeds._POST_ORDER_ACKNOWLEDGEMENT_DATA_(client, [{
+                const FeedContent = Feeds._POST_ORDER_ACKNOWLEDGEMENT_DATA_({
+                  MerchantIdentifier: '67890'
+                }, [{
                     MessageID: 1,
                     AmazonOrderID: '123-4567890-1234567',
                     MerchantOrderID: '12345',
@@ -83,13 +70,9 @@ describe('xml', () => {
 
         describe('_POST_ORDER_FULFILLMENT_DATA_', () => {
             it('should handle a single tracking number', () => {
-                const client = new MWSClient({
-                    accessKeyId: 'access',
-                    secretAccessKey: 'secret',
-                    merchantId: '67890'
-                });
-
-                const FeedContent = Feeds._POST_ORDER_FULFILLMENT_DATA_(client, {
+                const FeedContent = Feeds._POST_ORDER_FULFILLMENT_DATA_({
+                  MerchantIdentifier: '67890'
+                }, {
                     MessageID: 1,
                     MerchantOrderID: 1234567,
                     MerchantFulfillmentID: 1234567,
@@ -104,13 +87,9 @@ describe('xml', () => {
             });
 
             it('should handle a single tracking number as an array', () => {
-                const client = new MWSClient({
-                    accessKeyId: 'access',
-                    secretAccessKey: 'secret',
-                    merchantId: '67890'
-                });
-
-                const FeedContent = Feeds._POST_ORDER_FULFILLMENT_DATA_(client, {
+                const FeedContent = Feeds._POST_ORDER_FULFILLMENT_DATA_({
+                  MerchantIdentifier: '67890'
+                }, {
                     MessageID: 1,
                     MerchantOrderID: 1234567,
                     MerchantFulfillmentID: 1234567,
@@ -125,13 +104,9 @@ describe('xml', () => {
             });
 
             it('should handle multiple tracking numbers', () => {
-                const client = new MWSClient({
-                    accessKeyId: 'access',
-                    secretAccessKey: 'secret',
-                    merchantId: '67890'
-                });
-
-                const FeedContent = Feeds._POST_ORDER_FULFILLMENT_DATA_(client, {
+                const FeedContent = Feeds._POST_ORDER_FULFILLMENT_DATA_({
+                  MerchantIdentifier: '67890'
+                }, {
                     MessageID: 1,
                     MerchantOrderID: 1234567,
                     MerchantFulfillmentID: 1234567,
@@ -146,13 +121,9 @@ describe('xml', () => {
             });
 
             it('should handle multiple fulfillments', () => {
-                const client = new MWSClient({
-                    accessKeyId: 'access',
-                    secretAccessKey: 'secret',
-                    merchantId: '67890'
-                });
-
-                const FeedContent = Feeds._POST_ORDER_FULFILLMENT_DATA_(client, [{
+                const FeedContent = Feeds._POST_ORDER_FULFILLMENT_DATA_({
+                  MerchantIdentifier: '67890'
+                }, [{
                     MessageID: 1,
                     MerchantOrderID: 1234567,
                     MerchantFulfillmentID: 1234567,


### PR DESCRIPTION
Passing a header object instead of the client instance. As discussed in https://github.com/beardon/mws-api/issues/83

I think we could go with this for now, no?